### PR TITLE
Convert carbon cap inputs to metric tons

### DIFF
--- a/src/common/config_setup.py
+++ b/src/common/config_setup.py
@@ -14,6 +14,9 @@ from datetime import datetime
 import types
 import argparse
 
+# Constants
+SHORT_TON_TO_METRIC_TON = 0.90718474
+
 # Import python modules
 from definitions import PROJECT_ROOT
 from src.integrator.utilities import create_temporal_mapping
@@ -171,6 +174,19 @@ class Config_settings:
             self.start_year = config['start_year']
         else:
             self.start_year = self.years[0]
+
+        ############################################################################################
+        # __INIT__: Carbon Policy Configs
+        carbon_policy_section = config.get('carbon_policy')
+        if isinstance(carbon_policy_section, dict):
+            carbon_cap_value = carbon_policy_section.get('carbon_cap')
+        else:
+            carbon_cap_value = config.get('carbon_cap')
+
+        if carbon_cap_value in (None, ''):
+            self.carbon_cap = None
+        else:
+            self.carbon_cap = float(carbon_cap_value) * SHORT_TON_TO_METRIC_TON
 
         ############################################################################################
         # __INIT__:  Electricity Configs

--- a/src/common/run_config.toml
+++ b/src/common/run_config.toml
@@ -39,7 +39,7 @@ regions = [7,8,9] # representative region mapping switches
 ###################################################################################################
 # Electricity Inputs
 
-## Electricity feature switches 
+## Electricity feature switches
 ## Unless otherwise specified, 0=off, 1=on
 
 sw_trade = 1 # Interregional trade switch
@@ -56,6 +56,12 @@ sw_agg_years = 1
 # Turning this feature on, capital cost can be a function of the amount of capacity built by technology.
 # 0 = exogenous learning, 1 = iterative linear function, 2 = nonlinear function
 sw_learning = 0
+
+###################################################################################################
+# Carbon Policy Inputs
+
+# Provide the carbon cap in short tons; values are converted to metric tons internally.
+# carbon_cap = 0
 
 ###################################################################################################
 # Residential Inputs

--- a/src/common/run_config_template.toml
+++ b/src/common/run_config_template.toml
@@ -39,7 +39,7 @@ regions = [7,8,9] # representative region mapping switches
 ###################################################################################################
 # Electricity Inputs
 
-## Electricity feature switches 
+## Electricity feature switches
 ## Unless otherwise specified, 0=off, 1=on
 
 sw_trade = 1 # Interregional trade switch
@@ -56,6 +56,12 @@ sw_agg_years = 1
 # Turning this feature on, capital cost can be a function of the amount of capacity built by technology.
 # 0 = exogenous learning, 1 = iterative linear function, 2 = nonlinear function
 sw_learning = 0
+
+###################################################################################################
+# Carbon Policy Inputs
+
+# Provide the carbon cap in short tons; values are converted to metric tons internally.
+# carbon_cap = 0
 
 ###################################################################################################
 # Residential Inputs

--- a/unit_tests/common/test_config_carbon.py
+++ b/unit_tests/common/test_config_carbon.py
@@ -1,0 +1,27 @@
+"""Tests for configuration carbon policy handling."""
+
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip('pandas')
+
+from definitions import PROJECT_ROOT
+from src.common.config_setup import Config_settings, SHORT_TON_TO_METRIC_TON
+
+
+def test_carbon_cap_converts_short_tons_to_metric(tmp_path):
+    """Carbon cap values in short tons should be converted to metric tons."""
+
+    source_config = Path(PROJECT_ROOT, 'src/common', 'run_config.toml')
+    config_contents = source_config.read_text()
+
+    short_ton_cap = 1234.5
+    temp_config_path = tmp_path / 'run_config.toml'
+    temp_config_path.write_text(f"{config_contents}\ncarbon_cap = {short_ton_cap}\n")
+
+    settings = Config_settings(temp_config_path, test=True)
+
+    assert settings.carbon_cap == pytest.approx(
+        short_ton_cap * SHORT_TON_TO_METRIC_TON
+    )


### PR DESCRIPTION
## Summary
- add a short-ton to metric-ton conversion constant in the configuration loader and apply it to carbon caps
- document in the sample run configuration that users should supply carbon caps in short tons
- add a regression test that verifies the conversion from short-ton inputs to stored metric-ton values

## Testing
- pytest unit_tests/common/test_config_carbon.py

------
https://chatgpt.com/codex/tasks/task_e_68cac2650ca48327a698cb44d9b6b65b