### PR TITLE
Remove carbon price inputs and expose allowance duals

### DIFF
--- a/src/models/electricity/scripts/postprocessor.py
+++ b/src/models/electricity/scripts/postprocessor.py
@@ -23,7 +23,7 @@ from logging import getLogger
 from definitions import PROJECT_ROOT
 from src.models.electricity.scripts.utilities import create_obj_df
 
-PRICED_CONSTRAINTS = {'demand_balance', 'total_emissions_cap'}
+PRICED_CONSTRAINTS = {'demand_balance', 'total_emissions_cap', 'allowance_emissions_limit'}
 
 # Establish logger
 logger = getLogger(__name__)

--- a/unit_tests/electric/test_carbon_policy.py
+++ b/unit_tests/electric/test_carbon_policy.py
@@ -1,6 +1,8 @@
 import pytest
 import pyomo.environ as pyo
 
+from src.models.electricity.scripts.runner import record_allowance_emission_prices
+
 
 def build_allowance_model(
     years,
@@ -106,3 +108,46 @@ def test_emission_limit_detects_shortfall():
     assert model.year_emissions[2030].value <= (
         model.allowance_purchase[2030].value + incoming_2030
     )
+
+
+def test_reported_carbon_price_matches_marginal_cost():
+    baseline_emissions = 10.0
+    baseline_allowance = 8.0
+    abatement_cost = 25.0
+    tighten = 0.5
+    solver = pyo.SolverFactory('appsi_highs')
+
+    def solve_toy_model(allowance: float) -> pyo.ConcreteModel:
+        model = pyo.ConcreteModel()
+        model.dual = pyo.Suffix(direction=pyo.Suffix.IMPORT)
+        model.abatement = pyo.Var(domain=pyo.NonNegativeReals)
+        model.emissions = pyo.Var(domain=pyo.NonNegativeReals)
+        model.allowance_purchase = pyo.Var(domain=pyo.NonNegativeReals)
+
+        model.emissions_balance = pyo.Constraint(
+            expr=model.emissions == baseline_emissions - model.abatement
+        )
+        model.allowance_purchase_limit = pyo.Constraint(
+            expr=model.allowance_purchase <= allowance
+        )
+        model.allowance_emissions_limit = pyo.Constraint(
+            expr=model.emissions <= model.allowance_purchase
+        )
+        model.total_cost = pyo.Objective(expr=abatement_cost * model.abatement)
+
+        solver.solve(model)
+        record_allowance_emission_prices(model)
+        return model
+
+    baseline_model = solve_toy_model(baseline_allowance)
+    base_cost = pyo.value(baseline_model.total_cost)
+    base_price = baseline_model.carbon_prices.get(None)
+    assert base_price is not None and base_price > 0.0
+
+    tightened_model = solve_toy_model(baseline_allowance - tighten)
+    tightened_cost = pyo.value(tightened_model.total_cost)
+
+    delta_cost = tightened_cost - base_cost
+    expected_cost = base_price * tighten
+
+    assert delta_cost == pytest.approx(expected_cost, rel=1e-8, abs=1e-8)


### PR DESCRIPTION
## Summary
- drop the CarbonPrice parameter ingestion and objective cost from the electricity model
- record allowance emissions duals as positive modeled carbon prices and export them with other priced constraints
- add a regression test that validates the reported carbon price against the marginal cost of tightening an allowance limit

## Testing
- pytest unit_tests/electric/test_carbon_policy.py

------
https://chatgpt.com/codex/tasks/task_e_68cade6afbcc8327ae778b0609688e30