### PR TITLE
Support cap group carbon allowances

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,8 +2,6 @@ name: Tests
 
 on:
   push:
-    branches:
-      - main
   pull_request:
 
 jobs:
@@ -21,9 +19,13 @@ jobs:
         uses: conda-incubator/setup-miniconda@v2
         with:
           auto-activate-base: false
+          auto-update-conda: false
           activate-environment: bsky
           environment-file: envs/conda_env.yml
           use-mamba: true
+
+      - name: Show conda info
+        run: conda info
 
       - name: Run tests
         run: pytest unit_tests

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,11 +24,10 @@ jobs:
           environment-file: envs/conda_env.yml
           use-mamba: true
 
-      - name: Show conda info
-        run: conda info
-
-      - name: Show conda list
-        run: conda list
+      - name: Show conda diagnostics
+        run: |
+          conda info
+          conda list
 
       - name: Run tests
         run: pytest unit_tests

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,8 +5,8 @@ on:
   pull_request:
 
 jobs:
-  pytest:
-    name: Pytest
+  unit-tests:
+    name: unit-tests
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -26,6 +26,9 @@ jobs:
 
       - name: Show conda info
         run: conda info
+
+      - name: Show conda list
+        run: conda list
 
       - name: Run tests
         run: pytest unit_tests

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,5 +29,5 @@ jobs:
           conda info
           conda list
 
-      - name: Run tests
+      - name: Run unit tests
         run: pytest unit_tests

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,29 @@
+name: Tests
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  pytest:
+    name: Pytest
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash -l {0}
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Conda
+        uses: conda-incubator/setup-miniconda@v2
+        with:
+          auto-activate-base: false
+          activate-environment: bsky
+          environment-file: envs/conda_env.yml
+          use-mamba: true
+
+      - name: Run tests
+        run: pytest unit_tests

--- a/src/models/electricity/scripts/preprocessor.py
+++ b/src/models/electricity/scripts/preprocessor.py
@@ -833,7 +833,9 @@ def preprocessor(setin):
     all_frames['EmissionsRate'] = emissions_df
 
     # Carbon allowance group membership mapping
-    membership_df = all_frames.get('CarbonCapGroup')
+    membership_df = all_frames.pop('CarbonCapGroupMap', None)
+    if membership_df is None or membership_df.empty:
+        membership_df = all_frames.get('CarbonCapGroup')
     if membership_df is None or membership_df.empty:
         membership_df = pd.DataFrame(
             {'cap_group': ['system'] * len(setin.region), 'region': setin.region}


### PR DESCRIPTION
## Summary
- introduce cap group-aware carbon allowance inputs and region mapping, including updated configuration defaults
- extend the electricity preprocessor, model, and reporting to track allowance procurement, banking, and prices per cap group
- refresh carbon policy unit tests to cover two-group scenarios and ensure group-specific banking and pricing behavior
- resolve the CarbonCapGroupMap merge conflict by loading the mapping separately before emitting the membership parameter
- add a GitHub Actions workflow that provisions the bsky conda environment and executes the unit test suite so pandas and pyomo are available during CI

## Testing
- pytest unit_tests *(fails: ModuleNotFoundError: No module named 'pyomo')*


------
https://chatgpt.com/codex/tasks/task_e_68cb070a0be08327add9e2bd8aa21133