### PR TITLE
Update tests workflow to use conda env

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,20 +15,11 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up Conda environment
-        uses: conda-incubator/setup-miniconda@v3
+        uses: conda-incubator/setup-miniconda@v2
         with:
-          miniforge-version: latest
-          use-mamba: true
-          auto-update-conda: false
           auto-activate-base: false
           activate-environment: bsky
           environment-file: envs/conda_env.yml
-
-      - name: Install additional pip dependencies
-        shell: bash -l {0}
-        run: |
-          python -m pip install --upgrade pip
-          pip install -r requirements.txt
 
       - name: Run pytest
         shell: bash -l {0}


### PR DESCRIPTION
## Summary
- ensure the tests workflow provisions the bsky environment from envs/conda_env.yml via setup-miniconda@v2
- remove the fallback pip install step so CI relies solely on the managed conda environment

## Testing
- not run (CI only)


------
https://chatgpt.com/codex/tasks/task_e_68cb0a920ce48327af54603d6d7c0743