### PR TITLE
Allow overriding preprocessor frames

### DIFF
--- a/src/models/electricity/scripts/runner.py
+++ b/src/models/electricity/scripts/runner.py
@@ -198,7 +198,7 @@ def run_elec_model(settings: Config_settings, solve=True) -> PowerModel:
 
     logger.info('Preprocessing')
 
-    all_frames, setin = prep.preprocessor(prep.Sets(settings))
+    all_frames, setin = prep.preprocessor(prep.Sets(settings), frames_override=None)
 
     logger.debug(
         f'Proceeding to build model for years: {settings.years} and regions: {settings.regions}'


### PR DESCRIPTION
## Summary
- extend the electricity preprocessor to accept optional frame overrides and merge deep copies into the loaded inputs
- keep downstream usage intact while updating internal callers to pass the new optional argument explicitly so default behavior remains unchanged

## Testing
- pytest unit_tests/electric/test_sets.py *(fails: KeyError: 'sw_agg_years' when loading default test configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68cc07671ae883278fd5d83630455a7e