### PR TITLE
Refine carbon policy configuration handling

### DIFF
--- a/unit_tests/common/test_config_carbon.py
+++ b/unit_tests/common/test_config_carbon.py
@@ -13,13 +13,37 @@ from src.common.config_setup import Config_settings, SHORT_TON_TO_METRIC_TON
 def test_carbon_cap_groups_from_table(tmp_path):
     """Carbon cap groups defined in the table should populate the default group."""
 
-    source_config = Path(PROJECT_ROOT, 'src/common', 'run_config.toml')
-    config_contents = source_config.read_text()
-    config_contents = config_contents.replace(
-        'cap = "none" # Set to "none" for no cap',
-        'cap = 1234.5 # numeric cap for test',
-        1,
-    )
+    config_contents = """
+default_mode = "gs-combo"
+electricity = true
+hydrogen = true
+residential = true
+force_10 = false
+tol = 0.05
+max_iter = 12
+sw_temporal = "default"
+start_year = 2023
+years = [2025, 2030]
+regions = [7, 8, 9]
+sw_trade = 1
+sw_expansion = 1
+sw_rm = 1
+sw_ramp = 0
+sw_reserves = 1
+sw_agg_years = 1
+sw_learning = 0
+scale_load = "enduse"
+h2_data_folder = "input/hydrogen/all_regions"
+
+[[carbon_cap_groups]]
+name = "default"
+cap = 1234.5
+regions = [7, 8, 9]
+allowance_procurement = { "2025" = 50000000.0, "2030" = 40000000.0 }
+start_bank = 0.0
+bank_enabled = true
+allow_borrowing = false
+"""
 
     temp_config_path = tmp_path / 'run_config.toml'
     temp_config_path.write_text(config_contents)
@@ -27,12 +51,13 @@ def test_carbon_cap_groups_from_table(tmp_path):
     settings = Config_settings(temp_config_path, test=True)
 
     assert settings.default_cap_group is not None
-    assert settings.carbon_cap_groups[0] is settings.default_cap_group
+    first_name, first_group = next(iter(settings.carbon_cap_groups.items()))
+    assert settings.default_cap_group.name == first_name
     assert settings.carbon_cap == pytest.approx(1234.5)
-    assert settings.default_cap_group.allowance_procurement == settings.carbon_allowance_procurement
-    assert settings.default_cap_group.bank_enabled == settings.carbon_allowance_bank_enabled
+    assert first_group['allowance_procurement'] == settings.carbon_allowance_procurement
+    assert first_group['bank_enabled'] == settings.carbon_allowance_bank_enabled
     assert (
-        settings.default_cap_group.allow_borrowing
+        first_group['allow_borrowing']
         == settings.carbon_allowance_allow_borrowing
     )
 
@@ -84,6 +109,7 @@ def test_legacy_carbon_keys_create_default_group(tmp_path):
     assert group.regions == tuple(settings.regions)
     assert settings.carbon_cap == group.cap
     assert settings.carbon_allowance_procurement == group.allowance_procurement
+    assert settings.carbon_allowance_procurement_overrides == group.allowance_procurement_overrides
     assert settings.carbon_allowance_start_bank == group.start_bank
     assert settings.carbon_allowance_bank_enabled == group.bank_enabled
     assert settings.carbon_allowance_allow_borrowing == group.allow_borrowing


### PR DESCRIPTION
## Summary
- convert carbon policy parsing into a Config_settings instance method that normalizes groups, merges legacy keys, and seeds safe defaults
- adjust the carbon policy unit tests to use self-contained TOML fixtures and verify the updated structure, including procurement overrides

## Testing
- pytest unit_tests/common/test_config_carbon.py

------
https://chatgpt.com/codex/tasks/task_e_68cc12fa61488327a1f7fe2e9f12e015